### PR TITLE
Fix tabbing for example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ class FileResponseData(ResponseData):
         self._reader.close()
 
 def print_session_stats(stats):
-  print(stats)
+    print(stats)
 
 def print_server_stats(stats):
     counters = stats.get_and_reset_all_counters()


### PR DESCRIPTION
The rest of the example used 4 spaces except for this one line