### PR TITLE
Dropping Python 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.5-dev" # 3.5 development branch


### PR DESCRIPTION
Because if you're still using 3.3 you're doing it wrong :)