### PR TITLE
Add v4 TFTP Server Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-PYTHON=python3  # if there's no python3 binary this will fail first
+PYTHON=python3
+PYTHON3 := $(shell command -v python3)
+PYTHON35 := $(shell command -v python3.5)
+ifndef PYTHON3
+	ifdef PYTHON35
+		PYTHON=python3.5
+	endif
+endif
 PYTHON_MAJOR_AT_LEAST=3
 PYTHON_MINOR_AT_LEAST=3
 PYTHON_VERSION := $(shell $(PYTHON) -c 'from __future__ import print_function; import platform; print(platform.python_version())')

--- a/fbtftp/base_server.py
+++ b/fbtftp/base_server.py
@@ -200,8 +200,17 @@ class BaseServer:
         self._timeout = timeout
         self._server_stats_callback = server_stats_callback
         self._listener = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        try:
+            self._listener.bind((address, port))
+        except socket.gaierror as e:
+            if e.errno == socket.EAI_ADDRFAMILY:
+                self._listener = socket.socket(
+                    socket.AF_INET, socket.SOCK_DGRAM
+                )
+                self._listener.bind((address, port))
+            else:
+                raise
         self._listener.setblocking(0)  # non-blocking
-        self._listener.bind((address, port))
         self._epoll = select.epoll()
         self._epoll.register(self._listener.fileno(), select.EPOLLIN)
         self._should_stop = False

--- a/tests/base_server_test.py
+++ b/tests/base_server_test.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
+import socket
 from unittest.mock import patch, Mock
 import unittest
 
@@ -16,13 +17,13 @@ SELECT_EPOLLIN = 1
 
 
 class MockSocketListener:
-    def __init__(self, network_queue):
+    def __init__(self, network_queue, v4=False):
         self._network_queue = network_queue
+        self._peer = '127.0.0.2' if v4 else '::1'
 
     def recvfrom(self, blocksize):
         data = self._network_queue.pop(0)
-        peer = '::1'  # assuming v6, but this is invariant for this test
-        return data, peer
+        return data, self._peer
 
     def fileno(self):
         # just a given socket fileno that will have to be matched by
@@ -43,8 +44,8 @@ class StaticServer(BaseServer):
             address, port, retries, timeout, stats_callback, stats_interval
         )
         self._root = root
-        # mock the network
-        self._listener = MockSocketListener(network_queue)
+        self._listener = MockSocketListener(
+            network_queue, self._listener.family == socket.AF_INET)
         self._handler = None
 
     def get_handler(self, addr, peer, path, options):
@@ -59,8 +60,11 @@ class StaticServer(BaseServer):
 
 
 class testBaseServer(unittest.TestCase):
+
+    V4HOST = '127.0.0.1'
+    V6HOST = '::'
+
     def setUp(self):
-        self.host = '::'  # assuming v6, but this is invariant for this test
         self.port = 0  # let the kernel choose
         self.timeout = 100
         self.retries = 200
@@ -77,19 +81,37 @@ class testBaseServer(unittest.TestCase):
             return [(MOCK_SOCKET_FILENO, SELECT_EPOLLIN)]
         return []
 
-    def prepare_and_run(self, network_queue):
-        server = StaticServer(
-            self.host, self.port, self.retries, self.timeout, None, Mock(),
+    def get_server_v4(self):
+        return StaticServer(
+            self.V4HOST, self.port, self.retries, self.timeout, None, Mock(),
             self.interval, self.network_queue
         )
+
+    def get_server_v6(self):
+        return StaticServer(
+            self.V6HOST, self.port, self.retries, self.timeout, None, Mock(),
+            self.interval, self.network_queue
+        )
+
+    def prepare_and_run_server_v6(self):
+        handler = self.prepare_and_run_server(self.get_server_v6())
+        self.assertEqual(handler.addr, (self.V6HOST, 0))
+        self.assertEqual(handler.peer, '::1')
+        return handler
+
+    def prepare_and_run_server_v4(self):
+        handler = self.prepare_and_run_server(self.get_server_v4())
+        self.assertEqual(handler.addr, (self.V4HOST, 0))
+        self.assertEqual(handler.peer, '127.0.0.2')
+        return handler
+
+    def prepare_and_run_server(self, server):
         server._server_stats.increment_counter = Mock()
         server.run(run_once=True)
         server.close()
         self.assertTrue(server._should_stop)
         self.assertTrue(server._handler.daemon)
         server._handler.start.assert_called_with()
-        self.assertEqual(server._handler.addr, ('::', 0))
-        self.assertEqual(server._handler.peer, '::1')
         server._server_stats.increment_counter.assert_called_with(
             'process_count'
         )
@@ -99,49 +121,43 @@ class testBaseServer(unittest.TestCase):
     def testRRQ(self, epoll_mock):
         # link the self.poll_mock() method with the select.epoll patched object
         epoll_mock.return_value.poll.side_effect = self.poll_mock
-        self.network_queue = [
-            # RRQ + file name + mode + optname + optvalue
-            b'\x00\x01some_file\x00binascii\x00opt1_key\x00opt1_val\x00',
-        ]
-        handler = self.prepare_and_run(self.network_queue)
-
-        self.assertEqual(handler.path, 'some_file')
-        self.assertEqual(
-            handler.options, {
-                'default_timeout': 100,
-                'mode': 'binascii',
-                'opt1_key': 'opt1_val',
-                'retries': 200
-            }
-        )
+        # RRQ + file name + mode + optname + optvalue
+        payload = b'\x00\x01some_file\x00binascii\x00opt1_key\x00opt1_val\x00'
+        self.network_queue.append(payload)
+        handler_v6 = self.prepare_and_run_server_v6()
+        self.network_queue.append(payload)
+        handler_v4 = self.prepare_and_run_server_v4()
+        for handler in [handler_v4, handler_v6]:
+            self.assertEqual(handler.path, 'some_file')
+            self.assertEqual(
+                handler.options, {
+                    'default_timeout': 100,
+                    'mode': 'binascii',
+                    'opt1_key': 'opt1_val',
+                    'retries': 200
+                }
+            )
 
     def start_timer_and_wait_for_callback(self, stats_callback):
-        server = StaticServer(
-            self.host, self.port, self.retries, self.timeout, None,
-            stats_callback, self.interval, []
-        )
-        server.restart_stats_timer(run_once=True)
-        # wait for the stats callback to be executed
-        for i in range(10):
-            import time
-            time.sleep(1)
-            if stats_callback.mock_called:
-                print('Stats callback executed')
-                break
-        server._metrics_timer.cancel()
+        for server in [self.get_server_v4(), self.get_server_v6()]:
+            server.restart_stats_timer(run_once=True)
+            # wait for the stats callback to be executed
+            for i in range(10):
+                import time
+                time.sleep(1)
+                if stats_callback.mock_called:
+                    print('Stats callback executed')
+                    break
+            server._metrics_timer.cancel()
 
     def testTimer(self):
         stats_callback = Mock()
         self.start_timer_and_wait_for_callback(stats_callback)
 
     def testTimerNoCallBack(self):
-        stats_callback = None
-        server = StaticServer(
-            self.host, self.port, self.retries, self.timeout, None,
-            stats_callback, self.interval, []
-        )
-        ret = server.restart_stats_timer(run_once=True)
-        self.assertIsNone(ret)
+        for server in [self.get_server_v4(), self.get_server_v6()]:
+            ret = server.restart_stats_timer(run_once=True)
+            self.assertIsNone(ret)
 
     def testCallbackException(self):
         stats_callback = Mock()
@@ -152,13 +168,9 @@ class testBaseServer(unittest.TestCase):
     def testUnexpectedOpsCode(self, epoll_mock):
         # link the self.poll_mock() emthod with the select.epoll patched object
         epoll_mock.return_value.poll.side_effect = self.poll_mock
-        self.network_queue = [
-            # RRQ + file name + mode + optname + optvalue
-            b'\x00\xffsome_file\x00binascii\x00opt1_key\x00opt1_val\x00',
-        ]
-        server = StaticServer(
-            self.host, self.port, self.retries, self.timeout, None, Mock(),
-            self.interval, self.network_queue
-        )
-        server.run(run_once=True)
-        self.assertIsNone(server._handler)
+        # RRQ + file name + mode + optname + optvalue
+        payload = b'\x00\xffsome_file\x00binascii\x00opt1_key\x00opt1_val\x00'
+        for server in [self.get_server_v4(), self.get_server_v6()]:
+            self.network_queue.append(payload)
+            server.run(run_once=True)
+            self.assertIsNone(server._handler)


### PR DESCRIPTION
## Adding V4 TFTP Server Support

V4 host addresses did not work due to always using AF_INET6 when binding the server socket. I was looking to use this in a environment where netbooting over v6 is not possible (yet) and it was a simple fix to add in v4 support. 