### PR TITLE
Fix exception in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ class NoseTestCommand(TestCommand):
 
 
 here = path.abspath(path.dirname(__file__))
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
+with open(path.join(here, 'README.md'), 'rb') as f:
+    long_description = f.read().decode('utf-8')
 
 setup(
     name='fbtftp',


### PR DESCRIPTION
In Python 3 `open` doesn't have encoding argument
```
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/hm/6ss_99md5mv__pbnwxqvdssh0000gn/T/pip-build-x_fxDk/fbftp/setup.py", line 20, in <module>
        with open(path.join(here, 'README.md'), encoding='utf-8') as f:
    TypeError: 'encoding' is an invalid keyword argument for this function
```