### PR TITLE
Add effective support for ipv4

### DIFF
--- a/fbtftp/base_server.py
+++ b/fbtftp/base_server.py
@@ -7,6 +7,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 import collections
+import ipaddress
 import logging
 import select
 import socket
@@ -199,7 +200,13 @@ class BaseServer:
         self._retries = retries
         self._timeout = timeout
         self._server_stats_callback = server_stats_callback
-        self._listener = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        # the format of the peer tuple is different for v4 and v6
+        self._family = socket.AF_INET6
+        if isinstance(
+            ipaddress.ip_address(self._address), ipaddress.IPv4Address
+        ):
+            self._family = socket.AF_INET
+        self._listener = socket.socket(self._family, socket.SOCK_DGRAM)
         self._listener.setblocking(0)  # non-blocking
         self._listener.bind((address, port))
         self._epoll = select.epoll()


### PR DESCRIPTION
the support for the selection of the correct AF_INITx is properly made on base_handler but not on
base_server. So the same piece of code is reproducted.

/!\ no argument will raise an exception, but I think that it should be a normal biavior in this case