### PR TITLE
Ack TFTP options in request order.

### DIFF
--- a/fbtftp/base_handler.py
+++ b/fbtftp/base_handler.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
+from collections import OrderedDict
 import io
 import ipaddress
 import logging
@@ -192,7 +193,7 @@ class BaseHandler(multiprocessing.Process):
         Method that deals with parsing/validation options provided by the
         client.
         """
-        opts_to_ack = {}
+        opts_to_ack = OrderedDict()
         # We remove retries and default_timeout from self._options because
         # we don't need to include them in the OACK response to the client.
         # Their value is already hold in self._retries and self._timeout.
@@ -214,16 +215,21 @@ class BaseHandler(multiprocessing.Process):
             self._transmit_error()
             self._close()
             return  # no way anything else will succeed now
-        if 'blksize' in self._options:
-            opts_to_ack['blksize'] = self._options['blksize']
-            self._block_size = int(self._options['blksize'])
-        if 'tsize' in self._options:
-            self._tsize = self._response_data.size()
-            if self._tsize is not None:
-                opts_to_ack['tsize'] = str(self._tsize)
-        if 'timeout' in self._options:
-            opts_to_ack['timeout'] = self._options['timeout']
-            self._timeout = int(opts_to_ack['timeout'])
+        # Let's ack the options in the same order we got asked for them
+        # The RFC mentions that option order is not significant, but it can't
+        # hurt. This relies on Python 3.6 dicts to be ordered.
+        for k, v in self._options.items():
+            if k == 'blksize':
+                opts_to_ack['blksize'] = v
+                self._block_size = int(v)
+            if k == 'tsize':
+                self._tsize = self._response_data.size()
+                if self._tsize is not None:
+                    opts_to_ack['tsize'] = str(self._tsize)
+            if k == 'timeout':
+                opts_to_ack['timeout'] = v
+                self._timeout = int(v)
+
         self._options = opts_to_ack  # only ACK options we can handle
         logging.info(
             'Options to ack for peer {}:  {}'.format(

--- a/fbtftp/base_server.py
+++ b/fbtftp/base_server.py
@@ -314,11 +314,12 @@ class BaseServer:
             return
 
         path = tokens[0]
-        options = {
-            'mode': tokens[1].lower(),
-            'default_timeout': self._timeout,
-            'retries': self._retries,
-        }
+        options = collections.OrderedDict([
+            ('mode', tokens[1].lower()),
+            ('default_timeout', self._timeout),
+            ('retries', self._retries)
+        ]
+        )
         pos = 2
         while pos < len(tokens):
             options[tokens[pos].lower()] = tokens[pos + 1]

--- a/tests/base_handler_test.py
+++ b/tests/base_handler_test.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
+from collections import OrderedDict
 from unittest.mock import patch, Mock, call
 from fbtftp.netascii import NetasciiReader
 import socket
@@ -54,14 +55,14 @@ class MockHandler(BaseHandler):
 
 class testSessionHandler(unittest.TestCase):
     def setUp(self):
-        self.options = {
-            'default_timeout': 10,
-            'retries': 2,
-            'mode': 'netascii',
-            'blksize': 1492,
-            'tsize': 0,
-            'timeout': 99
-        }
+        self.options = OrderedDict([
+            ('default_timeout', 10),
+            ('retries', 2),
+            ('mode', 'netascii'),
+            ('blksize', 1492),
+            ('tsize', 0),
+            ('timeout', 99)
+        ])
 
         self.server_addr = ('127.0.0.1', 1234)
         self.peer = ('127.0.0.1', 5678)


### PR DESCRIPTION
The TFTP RFC mentions that "The order in which options are specified is not significant", so this should not be strictly necessary.

HOWEVER: With Python 3.6 dicts are ordered by default, so we inadvertently added an ordering.

At least this way, the ordering is not arbitrary depending on our source but rather the same order as the client requested.