### PR TITLE
Fix build error

### DIFF
--- a/fbtftp/base_handler.py
+++ b/fbtftp/base_handler.py
@@ -352,7 +352,7 @@ class BaseHandler(multiprocessing.Process):
             self._global_retransmits += 1
             return
 
-        error_msg = f'timeout after {self._retransmits} retransmits.'
+        error_msg = 'timeout after {} retransmits.'.format(self._retransmits)
         if self._waiting_last_ack:
             error_msg += ' Missed last ack.'
 


### PR DESCRIPTION
```python
error_msg = f'timeout after {self._retransmits} retransmits.'
                                                                ^
SyntaxError: invalid syntax
```
We can't use this syntax on Python 3.4 and 3.5
```python
f'timeout after {self._retransmits} retransmits.'
```