### PR TITLE
remove setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,5 @@ setup(
     url="https://www.github.com/facebook/fbtftp",
     packages=find_packages(exclude=["tests"]),
     tests_require=["nose", "coverage", "mock"],
-    setup_requires=["flake8"],
     cmdclass={"test": NoseTestCommand},
 )


### PR DESCRIPTION
setup_requires is a bear to configure if you're in a restrictive deployment environment behind a corporate firewall. it uses setuptools directly. so pip install will not respect pip configurations. in favor of setuptools configs. furthermore flake isn't really needed to just install and use the code.