### PR TITLE
removes setup_requires from setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ before_script:
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
       sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
     fi
+install:
+    - pip install flake8
 script: make test
 addons:
   apt:

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,5 @@ setup(
     url="https://www.github.com/facebook/fbtftp",
     packages=find_packages(exclude=["tests"]),
     tests_require=["nose", "coverage", "mock"],
-    setup_requires=["flake8"],
     cmdclass={"test": NoseTestCommand},
 )


### PR DESCRIPTION
As discussed before we can remove setup_requires from setup.py and just install flake8 inside travis ci container.