### PR TITLE
Fix: README.md - update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ class StaticServer(BaseServer):
             self._handler_stats_callback)
 
 def main():
-    server = StaticServer(ip='', port='1069', retries=3, timeout=5
+    server = StaticServer(address='::', port=69, retries=3, timeout=5,
                           root='/var/tftproot', 
                           handler_stats_callback=print_session_stats,
                           server_stats_callback=print_server_stats)


### PR DESCRIPTION
Dear fbtftp maintainers,

First many thanks for this code. I am going to use it in our own project (https://github.com/bluebanquise/bluebanquise) as we rely on the old atftp server that seems no more maintained. Also having a python written tool is a must for us.

During tests of fbtftp, I found that while the example file provided in examples/server.py is working (with a very nice verbosity output !), the example provided in the README.md is not.

Here are the changes done:

* Replace ip by address at StaticServer call
* Replace empty address by '::'
* Replace part as string to integer, and set to 69 default tftp port
* Add missing comma in example

With my best regards

Ox