### PR TITLE
Enable Linux and BSD compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  build:
-
+  build-linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,3 +25,24 @@ jobs:
     - name: Test
       run: |
         make test
+
+  build-bsd:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: [ '3.5', '3.6', '3.7', '3.8', '3.9' ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies and prepare for test
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools --upgrade
+          python -m pip install flake8
+      - name: Test
+        run: |
+          make test

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ and you are good to go:
 # Requirements
 
 * Linux (or any system that supports [`epoll`](http://linux.die.net/man/4/epoll))
-* Python 3.x
+* BSD (or any system that supports [`kqueue`](https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2))
+* Python 3.4+
 
 # Installation
 


### PR DESCRIPTION
Hey guys, first of all, great work on the framework. 

I need to use the framework on FreeBSD servers and it was quite a boomer when I saw it was depending on epoll, so I took some time and came up with this solution using `selectors` instead of `select`, that way things got OS agnostic and selectors should in theory use the most efficient method mechanism available. 

I took the care of also adjusting the `poll_mock()` in the tests. Please double check the work there as I was slightly unsure if that was the right way to go. 

Luiz